### PR TITLE
Add database entities using model first approach

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,3 @@
+Rails.application.config.generators do |g|
+    g.orm :active_record, primary_key_type: :uuid
+end

--- a/db/migrate/20220205220120_enable_uuid_primary_keys.rb
+++ b/db/migrate/20220205220120_enable_uuid_primary_keys.rb
@@ -1,0 +1,5 @@
+class EnableUuidPrimaryKeys < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20220205220840_create_users.rb
+++ b/db/migrate/20220205220840_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.string :full_name       ,null: false  ,limit: 71 ,index: true
+      t.string :nickname        ,null: false  ,limit: 50 ,index: { unique: true, name: 'unique_nicknames' }
+      t.string :email           ,null: false  ,limit: 255 ,index: { unique: true, name: 'unique_emails' }
+      t.string :password_digest ,null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,31 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_02_05_220840) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "full_name", limit: 71, null: false
+    t.string "nickname", limit: 50, null: false
+    t.string "email", limit: 255, null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "unique_emails", unique: true
+    t.index ["full_name"], name: "index_users_on_full_name"
+    t.index ["nickname"], name: "unique_nicknames", unique: true
+  end
+
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  full_name: MyString
+  nickname: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  full_name: MyString
+  nickname: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
To store application data we need to properly configure database entities and their relations.
For security reasons we prefer to configure uuid primary keys to prevent system entities enumeration.

## Test
1. Run `rails db:migrate` command to update database.
2. Connect to database using db manager. Check `id` column type of the `users` table.
*Optional: insert test user to check the `id` column type*