### PR TITLE
Implement user followers and followed by user mechanism on db level

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,7 @@
 class User < ApplicationRecord
+    has_many :followed          ,foreign_key: :follower_id  ,class_name: "UserFollower"
+    has_many :followed_users    ,through: :followed
+
+    has_many :followers         ,foreign_key: :user_id      ,class_name: "UserFollower"
+    has_many :following_users   ,through: :followers
 end

--- a/app/models/user_follower.rb
+++ b/app/models/user_follower.rb
@@ -1,0 +1,4 @@
+class UserFollower < ApplicationRecord
+    belongs_to  :user        ,class_name: "User"
+    belongs_to  :follower    ,class_name: "User"
+end

--- a/db/migrate/20220206085911_create_user_followers.rb
+++ b/db/migrate/20220206085911_create_user_followers.rb
@@ -1,0 +1,11 @@
+class CreateUserFollowers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_followers, primary_key: [:user_id, :follower_id] do |t|
+      t.uuid  :user_id      ,null: false
+      t.uuid  :follower_id  ,null: false
+      t.date  :followed_at  ,null: false  ,default: -> { 'now()' }
+    end
+    add_foreign_key :user_followers, :users, column: :user_id
+    add_foreign_key :user_followers, :users, column: :follower_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_05_220840) do
+ActiveRecord::Schema.define(version: 2022_02_06_085911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "user_followers", primary_key: ["user_id", "follower_id"], force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "follower_id", null: false
+    t.date "followed_at", default: -> { "now()" }, null: false
+  end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "full_name", limit: 71, null: false
@@ -28,4 +34,6 @@ ActiveRecord::Schema.define(version: 2022_02_05_220840) do
     t.index ["nickname"], name: "unique_nicknames", unique: true
   end
 
+  add_foreign_key "user_followers", "users"
+  add_foreign_key "user_followers", "users", column: "follower_id"
 end

--- a/test/fixtures/user_followers.yml
+++ b/test/fixtures/user_followers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  follower_id: 1
+  followed_at: 2022-02-06
+
+two:
+  user_id: 1
+  follower_id: 1
+  followed_at: 2022-02-06

--- a/test/models/user_follower_test.rb
+++ b/test/models/user_follower_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserFollowerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
We want to allow to each user follow other users and be followed by unlimited number of other users in the system. To achieve this, many to many relationship between `users` and `user_followers` tables has been configured.

## Test
1. Run `rails db:migrate` command to update database.
2. Connect db via SQL manager *(eg. PgAdmin4)* and run the following query:
```
SELECT
     tc.table_schema
    ,tc.table_name
    ,kcu.column_name
    ,ccu.table_schema AS foreign_table_schema
    ,ccu.table_name AS foreign_table_name
    ,ccu.column_name AS foreign_column_name
    ,tc.constraint_name
  FROM 
	information_schema.table_constraints AS tc 
  JOIN information_schema.key_column_usage AS kcu
	ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
  JOIN information_schema.constraint_column_usage AS ccu
	ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
 WHERE
 	1 = 1
   AND
	tc.constraint_type = 'FOREIGN KEY'
   AND
	tc.table_name = 'user_followers';
```
The query must return 2 references from `user_followers` table to `users` table:
- `user_id` => `id`
-  `follower_id` => `id`