### PR TITLE
Add posts entity to database

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20220206112256_create_posts.rb
+++ b/db/migrate/20220206112256_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts, id: :uuid do |t|
+      t.string      :content  ,null: false  ,limit: 140
+      t.references  :user     ,null: false  ,foreign_key: true  ,type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_06_085911) do
+ActiveRecord::Schema.define(version: 2022_02_06_112256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "content", limit: 140, null: false
+    t.uuid "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "user_followers", primary_key: ["user_id", "follower_id"], force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -34,6 +42,7 @@ ActiveRecord::Schema.define(version: 2022_02_06_085911) do
     t.index ["nickname"], name: "unique_nicknames", unique: true
   end
 
+  add_foreign_key "posts", "users"
   add_foreign_key "user_followers", "users"
   add_foreign_key "user_followers", "users", column: "follower_id"
 end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyString
+  user: one
+
+two:
+  content: MyString
+  user: two

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
As a microblog service we want to allow to our clients to create as much as they want posts within the system. To achieve this, `posts` table must be added to the database and it has to be referenced to the `users` table. Each post text must be limited by 140 characters long.

## Test
1. Run `rails db:migrate` command to update database
2. Connect to db and execute the following query:
```
SELECT
     tc.table_schema
    ,tc.table_name
    ,kcu.column_name
    ,ccu.table_schema AS foreign_table_schema
    ,ccu.table_name AS foreign_table_name
    ,ccu.column_name AS foreign_column_name
    ,tc.constraint_name
  FROM 
	information_schema.table_constraints AS tc 
  JOIN information_schema.key_column_usage AS kcu
	ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
  JOIN information_schema.constraint_column_usage AS ccu
	ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
 WHERE
 	1 = 1
   AND
	tc.constraint_type = 'FOREIGN KEY'
   AND
	tc.table_name = 'posts';
```
One reference from the `posts` table to `users` table must be returned: `user_id` => `id`.
3. Execute:
```
SELECT
	 table_name
	,column_name
	,data_type
	,character_maximum_length
  FROM
	information_schema.columns
 WHERE
	1 = 1
   AND
	table_schema = 'public'
   AND
   	table_name = 'posts';
```
Columns info must be returned. Check the `content` data type and maximum characters length. They should be *character varying* and *140* respectively.